### PR TITLE
Halifax Curation Script

### DIFF
--- a/wrapper_dcm2bids.sh
+++ b/wrapper_dcm2bids.sh
@@ -2,14 +2,54 @@
 
 # Wrapper to run dcm2bids on multiple subjects
 
+SOURCEDATA="$1"
+
+if [ ! -d "${SOURCEDATA}" ]; then
+  echo "${SOURCEDATA} is not a folder." >&2
+  exit 1
+fi
+
+CROSSWALK="$2"
+if [ ! -f "${CROSSWALK}" ]; then
+  echo "${CROSSWALK} is not a file." >&2
+  exit 1
+fi
+
+PARTICIPANTS="participants.tsv"
+if [ ! -f "${PARTICIPANTS}" ]; then
+  echo "${PARTICIPANTS} is not a file." >&2
+  exit 1
+fi
+
 # Loop through each line in the TSV file. Note that each row has several columns, separated by a tab.
-while IFS=$'\t' read -r participant_id source_id rest_of_line; do
+# TODO: handle Windows newlines
+while IFS=$'\t' read -r rhiscr_id imaging_id rest_of_line; do
+    # map imaging_id to participant_id
+    echo "rhiscr_id=|${rhiscr_id}|, imaging_id=|${imaging_id}|, rest_of_line=|${rest_of_line}|" # DEBUG
+
+    participant_id="$(grep "$imaging_id" "$PARTICIPANTS" | awk '{print $1}')"
+
+    if [ -z "$participant_id" ]; then
+      echo "${imaging_id} not found in ${PARTICIPANTS}" >&2
+      continue
+    fi
+
+    if [ ! -d "${SOURCEDATA}/${rhiscr_id} "*"/PAT01/DICOM/" ]; then
+      echo "source DICOM folder for ${imaging_id} not found" >&2
+      continue
+    fi
+
     # run dcm2bids
-    dcm2bids -d sourcedata/${source_id} -p ${participant_id} -c dicom_to_bids_config.json -o ./
+
+    #DICOM=
+    (set -x
+    echo dcm2bids -d "${SOURCEDATA}/${rhiscr_id} "*"/PAT01/DICOM/" -p "${participant_id}" -c code/dcm2bids_config.json -o ./
+    )
     #   -d -- source DICOM directory
     #   -p -- output participant ID
     #   -c -- JSON configuration file
     #   -o -- output BIDS directory
-done < <(sed 's/\r$//' participants.tsv | tail -n +2)
+done < <(sed 's/\r$//' "$CROSSWALK")
+#done < <(tail -n +2 participants.tsv)
 # tail -n +2 participants.tsv: remove the first line of the file (header)
 # <(...): this is a bash trick to read the output of a command as input of another command


### PR DESCRIPTION
This is the version of the curation script we are using for https://spineimage.ca/NSHA/site_012/.

* Makes `${SOURCEDATA}` a command line argument

There are some dataset-specific quirks:

* There is a third ID: the internal ID which are kept secret because they are linked to PII, Praxis's IDs (which), and the BIDS IDs; this is a complication that to me seems unnecessary -- we could skip Praxis's IDs, or use them directly as the BIDS IDs, but so it goes. So we need to map one to the other, and I added a second argument for that. I did mapped with `grep`, which isn't that reliable but was enough for a first draft.
*  instead of `${sourcedata}/${ID}`, the source data are in `D:\$ID $NAME\PAT01\DICOM`

Because of the quriks I don't think this should be merged, but I want to keep this branch handy. Maybe we can figure out something. For example, perhaps the mapping from RHSCIR IDs to Praxis(?) IDs can be a supplementary script that generates a temporary participants.tsv not to be committed with the extra column in it.